### PR TITLE
Enable auto-height and vertical centering for memo

### DIFF
--- a/frontend/src/components/RecordList.jsx
+++ b/frontend/src/components/RecordList.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef } from 'react';
 import { DataGrid } from '@mui/x-data-grid';
 import ConfirmDialog from './ConfirmDialog'
-import { Box, Collapse, IconButton, Typography } from '@mui/material';
+import { Box, Collapse, IconButton, Typography, TextField } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
@@ -147,6 +147,21 @@ function RecordList() {
                         {params.value}
                     </Typography>
                 </Box>
+            ),
+            renderEditCell: (params) => (
+                <TextField
+                    multiline
+                    minRows={1}
+                    fullWidth
+                    autoFocus
+                    value={params.value || ''}
+                    onChange={(e) =>
+                        params.api.setEditCellValue(
+                            { id: params.id, field: params.field, value: e.target.value },
+                            e
+                        )
+                    }
+                />
             )
         },
         {

--- a/frontend/src/components/RecordList.jsx
+++ b/frontend/src/components/RecordList.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from 'react';
-import { DataGrid } from '@mui/x-data-grid';
+import { DataGrid, gridClasses } from '@mui/x-data-grid';
 import ConfirmDialog from './ConfirmDialog'
 import { Box, Collapse, IconButton, Typography, TextField } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
@@ -139,19 +139,16 @@ function RecordList() {
             width: 200,
             editable: true,
             renderCell: (params) => (
-                <Box sx={{ display: 'flex', alignItems: 'center', height: '100%', width: '100%' }}>
-                    <Typography
-                        variant='body2'
-                        sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
-                    >
-                        {params.value}
-                    </Typography>
-                </Box>
+                <Typography
+                    variant='body2'
+                    sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
+                >
+                    {params.value}
+                </Typography>
             ),
             renderEditCell: (params) => (
                 <TextField
                     multiline
-                    minRows={1}
                     fullWidth
                     autoFocus
                     value={params.value || ''}
@@ -224,7 +221,12 @@ function RecordList() {
                             disableSelectionOnClick
                             processRowUpdate={processRowUpdate}
                             getRowHeight={() => 'auto'}
-                            sx={{ '& .MuiDataGrid-cell': { alignItems: 'center' } }}
+                            sx={{
+                                [`& .${gridClasses.cell}`]: {
+                                  py: 0,
+                                  alignContent: 'center'
+                                },
+                            }}
                             initialState={{
                                 sorting: {
                                     sortModel: [{ field: 'created_at', sort: 'desc' }],

--- a/frontend/src/components/RecordList.jsx
+++ b/frontend/src/components/RecordList.jsx
@@ -137,7 +137,17 @@ function RecordList() {
             field: 'memo',
             headerName: 'memo',
             width: 200,
-            editable: true
+            editable: true,
+            renderCell: (params) => (
+                <Box sx={{ display: 'flex', alignItems: 'center', height: '100%', width: '100%' }}>
+                    <Typography
+                        variant='body2'
+                        sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
+                    >
+                        {params.value}
+                    </Typography>
+                </Box>
+            )
         },
         {
             field: 'actions',
@@ -198,7 +208,8 @@ function RecordList() {
                             rowsPerPageOptions={[5]}
                             disableSelectionOnClick
                             processRowUpdate={processRowUpdate}
-                            rowHeight={38}
+                            getRowHeight={() => 'auto'}
+                            sx={{ '& .MuiDataGrid-cell': { alignItems: 'center' } }}
                             initialState={{
                                 sorting: {
                                     sortModel: [{ field: 'created_at', sort: 'desc' }],


### PR DESCRIPTION
## Summary
- center memo cell text vertically within the row
- keep automatic row height in `DataGrid`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest`