### PR TITLE
Display cumulative times for stopwatch

### DIFF
--- a/frontend/src/components/RecordingInterface.jsx
+++ b/frontend/src/components/RecordingInterface.jsx
@@ -243,6 +243,7 @@ function RecordingInterface() {
                         setActiveActivity(null);
                     }}
                     discordData={discordData}
+                    activityId={selectedActivity.id}
                     activityName={selectedActivity.name}
                     activityGroup={selectedActivity.group_name}
                     onTick={(time) => setMainDisplayTime(time)}


### PR DESCRIPTION
## Summary
- show the selected activity id to the Stopwatch component
- compute the last 7‑day and 30‑day totals including running time
- display these totals next to the stopwatch counter

## Testing
- `npm run lint -w frontend` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68782329192083299a0f3d916816b957