### PR TITLE
Add reorder feature for History items

### DIFF
--- a/frontend/src/components/History.jsx
+++ b/frontend/src/components/History.jsx
@@ -11,6 +11,14 @@ import HistoryDisplayDialog from './HistoryDisplayDialog';
 function History() {
     const { state: uiState, dispatch: uiDispatch } = useUI();
     const [settingsOpen, setSettingsOpen] = useState(false);
+
+    const componentsMap = {
+        chart: uiState.showChart ? <RecordChart key="chart" /> : null,
+        heatmap: uiState.showHeatmap ? <RecordHeatmap key="heatmap" /> : null,
+        calendar: uiState.showCalendar ? <RecordCalendar key="calendar" /> : null,
+        records: uiState.showRecords ? <RecordList key="records" /> : null,
+    };
+
     return (
         <Box sx={{ mb: 2 }}>
             {/* Heading / Title */}
@@ -59,10 +67,7 @@ function History() {
                     <SettingsIcon fontSize='small' />
                 </IconButton>
             </Box>
-            {uiState.showChart && <RecordChart />}
-            {uiState.showHeatmap && <RecordHeatmap />}
-            {uiState.showCalendar && <RecordCalendar />}
-            {uiState.showRecords && <RecordList />}
+            {uiState.historyOrder.map(key => componentsMap[key])}
             <HistoryDisplayDialog open={settingsOpen} onClose={() => setSettingsOpen(false)} />
         </Box>
     );

--- a/frontend/src/components/HistoryDisplayDialog.jsx
+++ b/frontend/src/components/HistoryDisplayDialog.jsx
@@ -10,6 +10,7 @@ import {
     Stack,
     Divider,
     Box,
+    IconButton,
 } from '@mui/material';
 import { useUI } from '../contexts/UIContext';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';

--- a/frontend/src/components/HistoryDisplayDialog.jsx
+++ b/frontend/src/components/HistoryDisplayDialog.jsx
@@ -12,6 +12,9 @@ import {
     Box,
 } from '@mui/material';
 import { useUI } from '../contexts/UIContext';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import { DEFAULT_HISTORY_ORDER } from '../reducers/uiReducer';
 
 const DEFAULT_VISIBILITY = {
     showChart: true,
@@ -27,6 +30,39 @@ function HistoryDisplayDialog({ open, onClose }) {
     const [tmpShowHeatmap, setTmpShowHeatmap] = useState(uiState.showHeatmap);
     const [tmpShowCalendar, setTmpShowCalendar] = useState(uiState.showCalendar);
     const [tmpShowRecords, setTmpShowRecords] = useState(uiState.showRecords);
+    const [tmpOrder, setTmpOrder] = useState(uiState.historyOrder);
+
+    const labelMap = {
+        chart: 'Chart',
+        heatmap: 'Heatmap',
+        calendar: 'Calendar',
+        records: 'Records',
+    };
+
+    const visibilityMap = {
+        chart: [tmpShowChart, setTmpShowChart],
+        heatmap: [tmpShowHeatmap, setTmpShowHeatmap],
+        calendar: [tmpShowCalendar, setTmpShowCalendar],
+        records: [tmpShowRecords, setTmpShowRecords],
+    };
+
+    const moveUp = (index) => {
+        if (index === 0) return;
+        setTmpOrder(prev => {
+            const arr = [...prev];
+            [arr[index - 1], arr[index]] = [arr[index], arr[index - 1]];
+            return arr;
+        });
+    };
+
+    const moveDown = (index) => {
+        if (index === tmpOrder.length - 1) return;
+        setTmpOrder(prev => {
+            const arr = [...prev];
+            [arr[index + 1], arr[index]] = [arr[index], arr[index + 1]];
+            return arr;
+        });
+    };
 
     useEffect(() => {
         if (open) {
@@ -34,6 +70,7 @@ function HistoryDisplayDialog({ open, onClose }) {
             setTmpShowHeatmap(uiState.showHeatmap);
             setTmpShowCalendar(uiState.showCalendar);
             setTmpShowRecords(uiState.showRecords);
+            setTmpOrder(uiState.historyOrder);
         }
     }, [open, uiState]);
 
@@ -42,6 +79,7 @@ function HistoryDisplayDialog({ open, onClose }) {
         setTmpShowHeatmap(DEFAULT_VISIBILITY.showHeatmap);
         setTmpShowCalendar(DEFAULT_VISIBILITY.showCalendar);
         setTmpShowRecords(DEFAULT_VISIBILITY.showRecords);
+        setTmpOrder([...DEFAULT_HISTORY_ORDER]);
     };
 
     return (
@@ -49,23 +87,26 @@ function HistoryDisplayDialog({ open, onClose }) {
             <DialogTitle>History Items</DialogTitle>
 
             <DialogContent dividers>
-                <Stack spacing={1} >
-                    <FormControlLabel
-                        control={<Switch checked={tmpShowChart} onChange={e => setTmpShowChart(e.target.checked)} />}
-                        label="Chart"
-                    />
-                    <FormControlLabel
-                        control={<Switch checked={tmpShowHeatmap} onChange={e => setTmpShowHeatmap(e.target.checked)} />}
-                        label="Heatmap"
-                    />
-                    <FormControlLabel
-                        control={<Switch checked={tmpShowCalendar} onChange={e => setTmpShowCalendar(e.target.checked)} />}
-                        label="Calendar"
-                    />
-                    <FormControlLabel
-                        control={<Switch checked={tmpShowRecords} onChange={e => setTmpShowRecords(e.target.checked)} />}
-                        label="Records"
-                    />
+                <Stack spacing={1}>
+                    {tmpOrder.map((key, index) => {
+                        const [checked, setter] = visibilityMap[key];
+                        return (
+                            <Box key={key} sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                                <FormControlLabel
+                                    control={<Switch checked={checked} onChange={e => setter(e.target.checked)} />}
+                                    label={labelMap[key]}
+                                />
+                                <Box>
+                                    <IconButton onClick={() => moveUp(index)} disabled={index === 0} size="small">
+                                        <ArrowUpwardIcon fontSize="inherit" />
+                                    </IconButton>
+                                    <IconButton onClick={() => moveDown(index)} disabled={index === tmpOrder.length - 1} size="small">
+                                        <ArrowDownwardIcon fontSize="inherit" />
+                                    </IconButton>
+                                </Box>
+                            </Box>
+                        );
+                    })}
                 </Stack>
             </DialogContent>
 
@@ -85,6 +126,7 @@ function HistoryDisplayDialog({ open, onClose }) {
                                     showHeatmap: tmpShowHeatmap,
                                     showCalendar: tmpShowCalendar,
                                     showRecords: tmpShowRecords,
+                                    historyOrder: tmpOrder,
                                 },
                             });
                             onClose();

--- a/frontend/src/reducers/uiReducer.js
+++ b/frontend/src/reducers/uiReducer.js
@@ -1,3 +1,10 @@
+export const DEFAULT_HISTORY_ORDER = [
+    'chart',
+    'heatmap',
+    'calendar',
+    'records',
+];
+
 export const initialUIState = {
     showGrid: false,
     groupDialogOpen: false,
@@ -16,6 +23,7 @@ export const initialUIState = {
     showHeatmap: true,
     showCalendar: true,
     showRecords: true,
+    historyOrder: [...DEFAULT_HISTORY_ORDER],
 };
 
 export function uiReducer(state, action) {
@@ -57,6 +65,8 @@ export function uiReducer(state, action) {
             return { ...state, showCalendar: action.payload };
         case 'SET_SHOW_RECORDS':
             return { ...state, showRecords: action.payload };
+        case 'SET_HISTORY_ORDER':
+            return { ...state, historyOrder: action.payload };
         // 一括変更
         case 'UPDATE_UI':
             return { ...state, ...action.payload };


### PR DESCRIPTION
## Summary
- allow users to reorder Chart, Heatmap, Calendar and Records
- persist order in UI state and support resetting to defaults
- display up/down arrows in History Items dialog for reordering

## Testing
- `npm --workspace frontend run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6880d0d519fc8329b5526e65c3bcdd34