### PR TITLE
Add Trend view under History

### DIFF
--- a/frontend/src/components/History.jsx
+++ b/frontend/src/components/History.jsx
@@ -4,6 +4,7 @@ import RecordList from './RecordList';
 import RecordHeatmap from './RecordHeatmap';
 import RecordCalendar from './RecordCalendar';
 import RecordChart from './RecordChart';
+import RecordTrend from './RecordTrend';
 import { useUI } from '../contexts/UIContext';
 import SettingsIcon from '@mui/icons-material/Settings';
 import HistoryDisplayDialog from './HistoryDisplayDialog';
@@ -15,6 +16,7 @@ function History() {
     const componentsMap = {
         chart: uiState.showChart ? <RecordChart key="chart" /> : null,
         heatmap: uiState.showHeatmap ? <RecordHeatmap key="heatmap" /> : null,
+        trend: uiState.showTrend ? <RecordTrend key="trend" /> : null,
         calendar: uiState.showCalendar ? <RecordCalendar key="calendar" /> : null,
         records: uiState.showRecords ? <RecordList key="records" /> : null,
     };
@@ -36,6 +38,7 @@ function History() {
                                 chartOpen: true,
                                 recordsOpen: true,
                                 heatmapOpen: true,
+                                trendOpen: true,
                                 calendarOpen: true,
                             }
                         })
@@ -54,6 +57,7 @@ function History() {
                                 chartOpen: false,
                                 recordsOpen: false,
                                 heatmapOpen: false,
+                                trendOpen: false,
                                 calendarOpen: false,
                             }
                         })

--- a/frontend/src/components/HistoryDisplayDialog.jsx
+++ b/frontend/src/components/HistoryDisplayDialog.jsx
@@ -22,6 +22,7 @@ const DEFAULT_VISIBILITY = {
     showHeatmap: true,
     showCalendar: true,
     showRecords: true,
+    showTrend: true,
 };
 
 function HistoryDisplayDialog({ open, onClose }) {
@@ -31,11 +32,13 @@ function HistoryDisplayDialog({ open, onClose }) {
     const [tmpShowHeatmap, setTmpShowHeatmap] = useState(uiState.showHeatmap);
     const [tmpShowCalendar, setTmpShowCalendar] = useState(uiState.showCalendar);
     const [tmpShowRecords, setTmpShowRecords] = useState(uiState.showRecords);
+    const [tmpShowTrend, setTmpShowTrend] = useState(uiState.showTrend);
     const [tmpOrder, setTmpOrder] = useState(uiState.historyOrder);
 
     const labelMap = {
         chart: 'Chart',
         heatmap: 'Heatmap',
+        trend: 'Trend',
         calendar: 'Calendar',
         records: 'Records',
     };
@@ -43,6 +46,7 @@ function HistoryDisplayDialog({ open, onClose }) {
     const visibilityMap = {
         chart: [tmpShowChart, setTmpShowChart],
         heatmap: [tmpShowHeatmap, setTmpShowHeatmap],
+        trend: [tmpShowTrend, setTmpShowTrend],
         calendar: [tmpShowCalendar, setTmpShowCalendar],
         records: [tmpShowRecords, setTmpShowRecords],
     };
@@ -71,6 +75,7 @@ function HistoryDisplayDialog({ open, onClose }) {
             setTmpShowHeatmap(uiState.showHeatmap);
             setTmpShowCalendar(uiState.showCalendar);
             setTmpShowRecords(uiState.showRecords);
+            setTmpShowTrend(uiState.showTrend);
             setTmpOrder(uiState.historyOrder);
         }
     }, [open, uiState]);
@@ -80,6 +85,7 @@ function HistoryDisplayDialog({ open, onClose }) {
         setTmpShowHeatmap(DEFAULT_VISIBILITY.showHeatmap);
         setTmpShowCalendar(DEFAULT_VISIBILITY.showCalendar);
         setTmpShowRecords(DEFAULT_VISIBILITY.showRecords);
+        setTmpShowTrend(DEFAULT_VISIBILITY.showTrend);
         setTmpOrder([...DEFAULT_HISTORY_ORDER]);
     };
 
@@ -127,6 +133,7 @@ function HistoryDisplayDialog({ open, onClose }) {
                                     showHeatmap: tmpShowHeatmap,
                                     showCalendar: tmpShowCalendar,
                                     showRecords: tmpShowRecords,
+                                    showTrend: tmpShowTrend,
                                     historyOrder: tmpOrder,
                                 },
                             });

--- a/frontend/src/components/RecordTrend.jsx
+++ b/frontend/src/components/RecordTrend.jsx
@@ -18,8 +18,6 @@ import { useRecords } from '../contexts/RecordContext';
 import { useUI } from '../contexts/UIContext';
 import { useFilter } from '../contexts/FilterContext';
 import useLocalStorageState from '../hooks/useLocalStorageState';
-import RecordFilter from './RecordFilter';
-import { useGroups } from '../contexts/GroupContext';
 
 function groupRecords(records, groupBy) {
     const now = DateTime.local();
@@ -132,8 +130,7 @@ function sortDecrease(data, by) {
 function RecordTrend() {
     const { records } = useRecords();
     const { state: uiState, dispatch: uiDispatch } = useUI();
-    const { filterState, setFilterState } = useFilter();
-    const { groups } = useGroups();
+    const { filterState } = useFilter();
     const [groupBy, setGroupBy] = useLocalStorageState('trend.groupBy', 'activity');
     const [incSortBy, setIncSortBy] = useLocalStorageState('trend.incSortBy', '7day');
     const [decSortBy, setDecSortBy] = useLocalStorageState('trend.decSortBy', '7day');
@@ -147,7 +144,6 @@ function RecordTrend() {
                 const tagNames = r.tags ? r.tags.map(t => t.name) : [];
                 if (!tagNames.includes(filterState.tagFilter)) return false;
             }
-            if (filterState.activityNameFilter && r.activity_name !== filterState.activityNameFilter) return false;
             return true;
         });
     }, [records, filterState]);
@@ -158,8 +154,6 @@ function RecordTrend() {
 
     const incRows = increase.slice(incPage * 10, incPage * 10 + 10);
     const decRows = decrease.slice(decPage * 10, decPage * 10 + 10);
-
-    const handleFilterChange = newCriteria => setFilterState(newCriteria);
 
     const headerStyle = { cursor: 'pointer', userSelect: 'none' };
 
@@ -182,8 +176,7 @@ function RecordTrend() {
                 />
             </Typography>
             <Collapse in={uiState.trendOpen}>
-                <Box sx={{ mb: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                    <RecordFilter groups={groups} onFilterChange={handleFilterChange} records={records} />
+                <Box sx={{ mb: 2, display: 'flex', justifyContent: 'flex-end', alignItems: 'center' }}>
                     <TextField select size='small' label='Group By' value={groupBy} onChange={e => setGroupBy(e.target.value)}>
                         <MenuItem value='activity'>Activity</MenuItem>
                         <MenuItem value='tag'>Tag</MenuItem>

--- a/frontend/src/components/RecordTrend.jsx
+++ b/frontend/src/components/RecordTrend.jsx
@@ -189,16 +189,10 @@ function RecordTrend() {
                 </Box>
                 <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
                     <Box sx={{ flex: 1, minWidth: 320, border: 1, borderColor: 'divider', borderRadius: 1, overflow: 'hidden' }}>
-                        <Typography
-                            variant='subtitle2'
-                            sx={(theme) => ({ px: 1, py: 0.5, backgroundColor: theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.04)' })}
-                        >
-                            Increase Ranking
-                        </Typography>
                         <Table size='small' sx={(theme) => ({ backgroundColor: theme.palette.mode === 'dark' ? '#222' : '#fafafa' })}>
                             <TableHead sx={(theme) => ({ backgroundColor: theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.04)' })}>
                                 <TableRow>
-                                    <TableCell />
+                                    <TableCell>Increase Ranking</TableCell>
                                     <TableCell onClick={() => setIncSortBy('7day')} sx={headerStyle}>
                                         7day {incSortBy === '7day' ? <ArrowDownwardIcon fontSize='inherit' /> : null}
                                     </TableCell>
@@ -212,10 +206,16 @@ function RecordTrend() {
                                     <TableRow key={row.name}>
                                         <TableCell>{row.name}</TableCell>
                                         <TableCell sx={{ color: row.diff7 > 0 ? 'green' : row.diff7 < 0 ? 'red' : 'inherit' }}>
-                                            {formatDiff(row.diff7, row.unit)} ({formatRate(row.total7, row.prev7)}){row.diff7 > 0 ? <TrendingUpIcon fontSize='inherit' /> : row.diff7 < 0 ? <TrendingDownIcon fontSize='inherit' /> : null}
+                                            {formatDiff(row.diff7, row.unit)}
+                                            {row.diff7 > 0 ? <TrendingUpIcon fontSize='inherit' /> : row.diff7 < 0 ? <TrendingDownIcon fontSize='inherit' /> : null}
+                                            <br />
+                                            ({formatRate(row.total7, row.prev7)})
                                         </TableCell>
                                         <TableCell sx={{ color: row.diff30 > 0 ? 'green' : row.diff30 < 0 ? 'red' : 'inherit' }}>
-                                            {formatDiff(row.diff30, row.unit)} ({formatRate(row.total30, row.prev30)}){row.diff30 > 0 ? <TrendingUpIcon fontSize='inherit' /> : row.diff30 < 0 ? <TrendingDownIcon fontSize='inherit' /> : null}
+                                            {formatDiff(row.diff30, row.unit)}
+                                            {row.diff30 > 0 ? <TrendingUpIcon fontSize='inherit' /> : row.diff30 < 0 ? <TrendingDownIcon fontSize='inherit' /> : null}
+                                            <br />
+                                            ({formatRate(row.total30, row.prev30)})
                                         </TableCell>
                                     </TableRow>
                                 ))}
@@ -231,16 +231,10 @@ function RecordTrend() {
                         />
                     </Box>
                     <Box sx={{ flex: 1, minWidth: 320, border: 1, borderColor: 'divider', borderRadius: 1, overflow: 'hidden' }}>
-                        <Typography
-                            variant='subtitle2'
-                            sx={(theme) => ({ px: 1, py: 0.5, backgroundColor: theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.04)' })}
-                        >
-                            Decrease Ranking
-                        </Typography>
                         <Table size='small' sx={(theme) => ({ backgroundColor: theme.palette.mode === 'dark' ? '#222' : '#fafafa' })}>
                             <TableHead sx={(theme) => ({ backgroundColor: theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.04)' })}>
                                 <TableRow>
-                                    <TableCell />
+                                    <TableCell>Decrease Ranking</TableCell>
                                     <TableCell onClick={() => setDecSortBy('7day')} sx={headerStyle}>
                                         7day {decSortBy === '7day' ? <ArrowUpwardIcon fontSize='inherit' /> : null}
                                     </TableCell>
@@ -254,10 +248,16 @@ function RecordTrend() {
                                     <TableRow key={row.name}>
                                         <TableCell>{row.name}</TableCell>
                                         <TableCell sx={{ color: row.diff7 > 0 ? 'green' : row.diff7 < 0 ? 'red' : 'inherit' }}>
-                                            {formatDiff(row.diff7, row.unit)} ({formatRate(row.total7, row.prev7)}){row.diff7 > 0 ? <TrendingUpIcon fontSize='inherit' /> : row.diff7 < 0 ? <TrendingDownIcon fontSize='inherit' /> : null}
+                                            {formatDiff(row.diff7, row.unit)}
+                                            {row.diff7 > 0 ? <TrendingUpIcon fontSize='inherit' /> : row.diff7 < 0 ? <TrendingDownIcon fontSize='inherit' /> : null}
+                                            <br />
+                                            ({formatRate(row.total7, row.prev7)})
                                         </TableCell>
                                         <TableCell sx={{ color: row.diff30 > 0 ? 'green' : row.diff30 < 0 ? 'red' : 'inherit' }}>
-                                            {formatDiff(row.diff30, row.unit)} ({formatRate(row.total30, row.prev30)}){row.diff30 > 0 ? <TrendingUpIcon fontSize='inherit' /> : row.diff30 < 0 ? <TrendingDownIcon fontSize='inherit' /> : null}
+                                            {formatDiff(row.diff30, row.unit)}
+                                            {row.diff30 > 0 ? <TrendingUpIcon fontSize='inherit' /> : row.diff30 < 0 ? <TrendingDownIcon fontSize='inherit' /> : null}
+                                            <br />
+                                            ({formatRate(row.total30, row.prev30)})
                                         </TableCell>
                                     </TableRow>
                                 ))}

--- a/frontend/src/components/RecordTrend.jsx
+++ b/frontend/src/components/RecordTrend.jsx
@@ -13,6 +13,10 @@ import {
     MenuItem
 } from '@mui/material';
 import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import TrendingUpIcon from '@mui/icons-material/TrendingUp';
+import TrendingDownIcon from '@mui/icons-material/TrendingDown';
 import { DateTime } from 'luxon';
 import { useRecords } from '../contexts/RecordContext';
 import { useUI } from '../contexts/UIContext';
@@ -184,16 +188,22 @@ function RecordTrend() {
                     </TextField>
                 </Box>
                 <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
-                    <Box sx={{ flex: 1, minWidth: 320 }}>
-                        <Table size='small'>
-                            <TableHead>
+                    <Box sx={{ flex: 1, minWidth: 320, border: 1, borderColor: 'divider', borderRadius: 1, overflow: 'hidden' }}>
+                        <Typography
+                            variant='subtitle2'
+                            sx={(theme) => ({ px: 1, py: 0.5, backgroundColor: theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.04)' })}
+                        >
+                            Increase Ranking
+                        </Typography>
+                        <Table size='small' sx={(theme) => ({ backgroundColor: theme.palette.mode === 'dark' ? '#222' : '#fafafa' })}>
+                            <TableHead sx={(theme) => ({ backgroundColor: theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.04)' })}>
                                 <TableRow>
-                                    <TableCell>項目名</TableCell>
+                                    <TableCell />
                                     <TableCell onClick={() => setIncSortBy('7day')} sx={headerStyle}>
-                                        7day {incSortBy === '7day' ? '↓' : ''}
+                                        7day {incSortBy === '7day' ? <ArrowDownwardIcon fontSize='inherit' /> : null}
                                     </TableCell>
                                     <TableCell onClick={() => setIncSortBy('30day')} sx={headerStyle}>
-                                        30day {incSortBy === '30day' ? '↓' : ''}
+                                        30day {incSortBy === '30day' ? <ArrowDownwardIcon fontSize='inherit' /> : null}
                                     </TableCell>
                                 </TableRow>
                             </TableHead>
@@ -202,10 +212,10 @@ function RecordTrend() {
                                     <TableRow key={row.name}>
                                         <TableCell>{row.name}</TableCell>
                                         <TableCell sx={{ color: row.diff7 > 0 ? 'green' : row.diff7 < 0 ? 'red' : 'inherit' }}>
-                                            {formatDiff(row.diff7, row.unit)} ({formatRate(row.total7, row.prev7)}){row.diff7 > 0 ? '↗' : row.diff7 < 0 ? '↘' : ''}
+                                            {formatDiff(row.diff7, row.unit)} ({formatRate(row.total7, row.prev7)}){row.diff7 > 0 ? <TrendingUpIcon fontSize='inherit' /> : row.diff7 < 0 ? <TrendingDownIcon fontSize='inherit' /> : null}
                                         </TableCell>
                                         <TableCell sx={{ color: row.diff30 > 0 ? 'green' : row.diff30 < 0 ? 'red' : 'inherit' }}>
-                                            {formatDiff(row.diff30, row.unit)} ({formatRate(row.total30, row.prev30)}){row.diff30 > 0 ? '↗' : row.diff30 < 0 ? '↘' : ''}
+                                            {formatDiff(row.diff30, row.unit)} ({formatRate(row.total30, row.prev30)}){row.diff30 > 0 ? <TrendingUpIcon fontSize='inherit' /> : row.diff30 < 0 ? <TrendingDownIcon fontSize='inherit' /> : null}
                                         </TableCell>
                                     </TableRow>
                                 ))}
@@ -220,16 +230,22 @@ function RecordTrend() {
                             rowsPerPageOptions={[10]}
                         />
                     </Box>
-                    <Box sx={{ flex: 1, minWidth: 320 }}>
-                        <Table size='small'>
-                            <TableHead>
+                    <Box sx={{ flex: 1, minWidth: 320, border: 1, borderColor: 'divider', borderRadius: 1, overflow: 'hidden' }}>
+                        <Typography
+                            variant='subtitle2'
+                            sx={(theme) => ({ px: 1, py: 0.5, backgroundColor: theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.04)' })}
+                        >
+                            Decrease Ranking
+                        </Typography>
+                        <Table size='small' sx={(theme) => ({ backgroundColor: theme.palette.mode === 'dark' ? '#222' : '#fafafa' })}>
+                            <TableHead sx={(theme) => ({ backgroundColor: theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.04)' })}>
                                 <TableRow>
-                                    <TableCell>項目名</TableCell>
+                                    <TableCell />
                                     <TableCell onClick={() => setDecSortBy('7day')} sx={headerStyle}>
-                                        7day {decSortBy === '7day' ? '↑' : ''}
+                                        7day {decSortBy === '7day' ? <ArrowUpwardIcon fontSize='inherit' /> : null}
                                     </TableCell>
                                     <TableCell onClick={() => setDecSortBy('30day')} sx={headerStyle}>
-                                        30day {decSortBy === '30day' ? '↑' : ''}
+                                        30day {decSortBy === '30day' ? <ArrowUpwardIcon fontSize='inherit' /> : null}
                                     </TableCell>
                                 </TableRow>
                             </TableHead>
@@ -238,10 +254,10 @@ function RecordTrend() {
                                     <TableRow key={row.name}>
                                         <TableCell>{row.name}</TableCell>
                                         <TableCell sx={{ color: row.diff7 > 0 ? 'green' : row.diff7 < 0 ? 'red' : 'inherit' }}>
-                                            {formatDiff(row.diff7, row.unit)} ({formatRate(row.total7, row.prev7)}){row.diff7 > 0 ? '↗' : row.diff7 < 0 ? '↘' : ''}
+                                            {formatDiff(row.diff7, row.unit)} ({formatRate(row.total7, row.prev7)}){row.diff7 > 0 ? <TrendingUpIcon fontSize='inherit' /> : row.diff7 < 0 ? <TrendingDownIcon fontSize='inherit' /> : null}
                                         </TableCell>
                                         <TableCell sx={{ color: row.diff30 > 0 ? 'green' : row.diff30 < 0 ? 'red' : 'inherit' }}>
-                                            {formatDiff(row.diff30, row.unit)} ({formatRate(row.total30, row.prev30)}){row.diff30 > 0 ? '↗' : row.diff30 < 0 ? '↘' : ''}
+                                            {formatDiff(row.diff30, row.unit)} ({formatRate(row.total30, row.prev30)}){row.diff30 > 0 ? <TrendingUpIcon fontSize='inherit' /> : row.diff30 < 0 ? <TrendingDownIcon fontSize='inherit' /> : null}
                                         </TableCell>
                                     </TableRow>
                                 ))}

--- a/frontend/src/components/RecordTrend.jsx
+++ b/frontend/src/components/RecordTrend.jsx
@@ -1,0 +1,272 @@
+import React, { useMemo, useState } from 'react';
+import {
+    Box,
+    Typography,
+    Collapse,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableRow,
+    TablePagination,
+    TextField,
+    MenuItem
+} from '@mui/material';
+import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
+import { DateTime } from 'luxon';
+import { useRecords } from '../contexts/RecordContext';
+import { useUI } from '../contexts/UIContext';
+import { useFilter } from '../contexts/FilterContext';
+import useLocalStorageState from '../hooks/useLocalStorageState';
+import RecordFilter from './RecordFilter';
+import { useGroups } from '../contexts/GroupContext';
+
+function groupRecords(records, groupBy) {
+    const now = DateTime.local();
+    const start7 = now.minus({ days: 7 });
+    const start14 = now.minus({ days: 14 });
+    const start30 = now.minus({ days: 30 });
+    const start60 = now.minus({ days: 60 });
+    const map = new Map();
+
+    records.forEach(rec => {
+        let keys = [];
+        if (groupBy === 'activity') {
+            keys.push(rec.activity_name || 'Unknown Activity');
+        } else if (groupBy === 'group') {
+            keys.push(rec.activity_group || 'Unknown Group');
+        } else if (groupBy === 'tag') {
+            if (rec.tags && rec.tags.length > 0) {
+                rec.tags.forEach(t => keys.push(t.name));
+            } else {
+                keys.push('No Tag');
+            }
+        }
+        const dt = DateTime.fromISO(rec.created_at, { zone: 'utc' }).toLocal();
+        keys.forEach(key => {
+            if (!map.has(key)) {
+                map.set(key, {
+                    name: key,
+                    unit: rec.unit,
+                    total7: 0,
+                    prev7: 0,
+                    total30: 0,
+                    prev30: 0,
+                    last: dt
+                });
+            }
+            const obj = map.get(key);
+            if (dt > obj.last) obj.last = dt;
+            if (dt >= start7) obj.total7 += rec.value;
+            else if (dt >= start14) obj.prev7 += rec.value;
+            if (dt >= start30) obj.total30 += rec.value;
+            else if (dt >= start60) obj.prev30 += rec.value;
+        });
+    });
+
+    const arr = [];
+    map.forEach(v => {
+        const total60 = v.total30 + v.prev30;
+        if (total60 === 0) return;
+        arr.push({
+            ...v,
+            diff7: v.total7 - v.prev7,
+            diff30: v.total30 - v.prev30,
+            rate7: v.prev7 === 0 ? null : ((v.total7 / v.prev7 - 1) * 100),
+            rate30: v.prev30 === 0 ? null : ((v.total30 / v.prev30 - 1) * 100)
+        });
+    });
+    return arr;
+}
+
+function formatDiff(val, unit) {
+    const sign = val > 0 ? '+' : val < 0 ? '-' : '';
+    const abs = Math.abs(val);
+    if (unit === 'minutes') {
+        const hours = Math.floor(abs / 60);
+        const minutes = Math.floor(abs % 60);
+        return `${sign}${hours}:${String(minutes).padStart(2, '0')}`;
+    }
+    return `${sign}${Math.round(abs)}`;
+}
+
+function formatRate(total, prev) {
+    if (total === 0 && prev === 0) return ' - ';
+    if (total !== 0 && prev === 0) return 'new!!';
+    const rate = (total / prev - 1) * 100;
+    return `${rate >= 0 ? '+' : ''}${rate.toFixed(1)}%`;
+}
+
+function sortIncrease(data, by) {
+    const totalField = by === '7day' ? 'total7' : 'total30';
+    const prevField = by === '7day' ? 'prev7' : 'prev30';
+    return [...data].sort((a, b) => {
+        const aNew = a[totalField] !== 0 && a[prevField] === 0;
+        const bNew = b[totalField] !== 0 && b[prevField] === 0;
+        if (aNew && !bNew) return -1;
+        if (!aNew && bNew) return 1;
+        const aZero = a[totalField] === 0 && a[prevField] === 0;
+        const bZero = b[totalField] === 0 && b[prevField] === 0;
+        if (aZero && !bZero) return 1;
+        if (!aZero && bZero) return -1;
+        const rateA = a[prevField] === 0 ? -Infinity : (a[totalField] / a[prevField] - 1);
+        const rateB = b[prevField] === 0 ? -Infinity : (b[totalField] / b[prevField] - 1);
+        if (rateB !== rateA) return rateB - rateA;
+        if (b[totalField] !== a[totalField]) return b[totalField] - a[totalField];
+        return b.last - a.last;
+    });
+}
+
+function sortDecrease(data, by) {
+    const totalField = by === '7day' ? 'total7' : 'total30';
+    const prevField = by === '7day' ? 'prev7' : 'prev30';
+    return [...data].sort((a, b) => {
+        const rateA = a[prevField] === 0 ? Infinity : (a[totalField] / a[prevField] - 1);
+        const rateB = b[prevField] === 0 ? Infinity : (b[totalField] / b[prevField] - 1);
+        if (rateA !== rateB) return rateA - rateB;
+        if (a[totalField] !== b[totalField]) return a[totalField] - b[totalField];
+        return a.last - b.last;
+    });
+}
+
+function RecordTrend() {
+    const { records } = useRecords();
+    const { state: uiState, dispatch: uiDispatch } = useUI();
+    const { filterState, setFilterState } = useFilter();
+    const { groups } = useGroups();
+    const [groupBy, setGroupBy] = useLocalStorageState('trend.groupBy', 'activity');
+    const [incSortBy, setIncSortBy] = useLocalStorageState('trend.incSortBy', '7day');
+    const [decSortBy, setDecSortBy] = useLocalStorageState('trend.decSortBy', '7day');
+    const [incPage, setIncPage] = useState(0);
+    const [decPage, setDecPage] = useState(0);
+
+    const filteredRecords = useMemo(() => {
+        return records.filter(r => {
+            if (filterState.groupFilter && r.activity_group !== filterState.groupFilter) return false;
+            if (filterState.tagFilter) {
+                const tagNames = r.tags ? r.tags.map(t => t.name) : [];
+                if (!tagNames.includes(filterState.tagFilter)) return false;
+            }
+            if (filterState.activityNameFilter && r.activity_name !== filterState.activityNameFilter) return false;
+            return true;
+        });
+    }, [records, filterState]);
+
+    const grouped = useMemo(() => groupRecords(filteredRecords, groupBy), [filteredRecords, groupBy]);
+    const increase = useMemo(() => sortIncrease(grouped, incSortBy), [grouped, incSortBy]);
+    const decrease = useMemo(() => sortDecrease(grouped, decSortBy), [grouped, decSortBy]);
+
+    const incRows = increase.slice(incPage * 10, incPage * 10 + 10);
+    const decRows = decrease.slice(decPage * 10, decPage * 10 + 10);
+
+    const handleFilterChange = newCriteria => setFilterState(newCriteria);
+
+    const headerStyle = { cursor: 'pointer', userSelect: 'none' };
+
+    return (
+        <Box sx={{ mb: 1 }}>
+            <Typography
+                variant='caption'
+                color='#cccccc'
+                sx={{ alignItems: 'center', display: 'flex', cursor: 'pointer' }}
+                onClick={() => uiDispatch({ type: 'SET_TREND_OPEN', payload: !uiState.trendOpen })}
+            >
+                Trend
+                <KeyboardArrowRightIcon
+                    fontSize='small'
+                    sx={{
+                        transition: 'transform 0.15s linear',
+                        transform: uiState.trendOpen ? 'rotate(90deg)' : 'rotate(0deg)',
+                        marginLeft: '4px'
+                    }}
+                />
+            </Typography>
+            <Collapse in={uiState.trendOpen}>
+                <Box sx={{ mb: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                    <RecordFilter groups={groups} onFilterChange={handleFilterChange} records={records} />
+                    <TextField select size='small' label='Group By' value={groupBy} onChange={e => setGroupBy(e.target.value)}>
+                        <MenuItem value='activity'>Activity</MenuItem>
+                        <MenuItem value='tag'>Tag</MenuItem>
+                        <MenuItem value='group'>Group</MenuItem>
+                    </TextField>
+                </Box>
+                <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+                    <Box sx={{ flex: 1, minWidth: 320 }}>
+                        <Table size='small'>
+                            <TableHead>
+                                <TableRow>
+                                    <TableCell>項目名</TableCell>
+                                    <TableCell onClick={() => setIncSortBy('7day')} sx={headerStyle}>
+                                        7day {incSortBy === '7day' ? '↓' : ''}
+                                    </TableCell>
+                                    <TableCell onClick={() => setIncSortBy('30day')} sx={headerStyle}>
+                                        30day {incSortBy === '30day' ? '↓' : ''}
+                                    </TableCell>
+                                </TableRow>
+                            </TableHead>
+                            <TableBody>
+                                {incRows.map(row => (
+                                    <TableRow key={row.name}>
+                                        <TableCell>{row.name}</TableCell>
+                                        <TableCell sx={{ color: row.diff7 > 0 ? 'green' : row.diff7 < 0 ? 'red' : 'inherit' }}>
+                                            {formatDiff(row.diff7, row.unit)} ({formatRate(row.total7, row.prev7)}){row.diff7 > 0 ? '↗' : row.diff7 < 0 ? '↘' : ''}
+                                        </TableCell>
+                                        <TableCell sx={{ color: row.diff30 > 0 ? 'green' : row.diff30 < 0 ? 'red' : 'inherit' }}>
+                                            {formatDiff(row.diff30, row.unit)} ({formatRate(row.total30, row.prev30)}){row.diff30 > 0 ? '↗' : row.diff30 < 0 ? '↘' : ''}
+                                        </TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                        <TablePagination
+                            component='div'
+                            count={increase.length}
+                            page={incPage}
+                            onPageChange={(e, p) => setIncPage(p)}
+                            rowsPerPage={10}
+                            rowsPerPageOptions={[10]}
+                        />
+                    </Box>
+                    <Box sx={{ flex: 1, minWidth: 320 }}>
+                        <Table size='small'>
+                            <TableHead>
+                                <TableRow>
+                                    <TableCell>項目名</TableCell>
+                                    <TableCell onClick={() => setDecSortBy('7day')} sx={headerStyle}>
+                                        7day {decSortBy === '7day' ? '↑' : ''}
+                                    </TableCell>
+                                    <TableCell onClick={() => setDecSortBy('30day')} sx={headerStyle}>
+                                        30day {decSortBy === '30day' ? '↑' : ''}
+                                    </TableCell>
+                                </TableRow>
+                            </TableHead>
+                            <TableBody>
+                                {decRows.map(row => (
+                                    <TableRow key={row.name}>
+                                        <TableCell>{row.name}</TableCell>
+                                        <TableCell sx={{ color: row.diff7 > 0 ? 'green' : row.diff7 < 0 ? 'red' : 'inherit' }}>
+                                            {formatDiff(row.diff7, row.unit)} ({formatRate(row.total7, row.prev7)}){row.diff7 > 0 ? '↗' : row.diff7 < 0 ? '↘' : ''}
+                                        </TableCell>
+                                        <TableCell sx={{ color: row.diff30 > 0 ? 'green' : row.diff30 < 0 ? 'red' : 'inherit' }}>
+                                            {formatDiff(row.diff30, row.unit)} ({formatRate(row.total30, row.prev30)}){row.diff30 > 0 ? '↗' : row.diff30 < 0 ? '↘' : ''}
+                                        </TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                        <TablePagination
+                            component='div'
+                            count={decrease.length}
+                            page={decPage}
+                            onPageChange={(e, p) => setDecPage(p)}
+                            rowsPerPage={10}
+                            rowsPerPageOptions={[10]}
+                        />
+                    </Box>
+                </Box>
+            </Collapse>
+        </Box>
+    );
+}
+
+export default RecordTrend;

--- a/frontend/src/reducers/uiReducer.js
+++ b/frontend/src/reducers/uiReducer.js
@@ -1,6 +1,7 @@
 export const DEFAULT_HISTORY_ORDER = [
     'chart',
     'heatmap',
+    'trend',
     'calendar',
     'records',
 ];
@@ -19,10 +20,12 @@ export const initialUIState = {
     heatmapOpen: true,
     calendarOpen: true,
     recordsOpen: true,
+    trendOpen: true,
     showChart: true,
     showHeatmap: true,
     showCalendar: true,
     showRecords: true,
+    showTrend: true,
     historyOrder: [...DEFAULT_HISTORY_ORDER],
 };
 
@@ -56,6 +59,8 @@ export function uiReducer(state, action) {
             return { ...state, calendarOpen: action.payload };
         case 'SET_RECORDS_OPEN':
             return { ...state, recordsOpen: action.payload };
+        case 'SET_TREND_OPEN':
+            return { ...state, trendOpen: action.payload };
         // History項目の表示有無
         case 'SET_SHOW_CHART':
             return { ...state, showChart: action.payload };
@@ -65,6 +70,8 @@ export function uiReducer(state, action) {
             return { ...state, showCalendar: action.payload };
         case 'SET_SHOW_RECORDS':
             return { ...state, showRecords: action.payload };
+        case 'SET_SHOW_TREND':
+            return { ...state, showTrend: action.payload };
         case 'SET_HISTORY_ORDER':
             return { ...state, historyOrder: action.payload };
         // 一括変更


### PR DESCRIPTION
## Summary
- include Trend component in History order and visibility settings
- allow toggling Trend display in History Items dialog
- manage new UI state fields for Trend
- implement `RecordTrend` component with sorting and paging

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6880da7d0564832980143d23915f0342