### PR TITLE
Improve trend text contrast

### DIFF
--- a/frontend/src/components/RecordTrend.jsx
+++ b/frontend/src/components/RecordTrend.jsx
@@ -205,13 +205,39 @@ function RecordTrend() {
                                 {incRows.map(row => (
                                     <TableRow key={row.name}>
                                         <TableCell>{row.name}</TableCell>
-                                        <TableCell sx={{ color: row.diff7 > 0 ? 'green' : row.diff7 < 0 ? 'red' : 'inherit' }}>
+                                        <TableCell
+                                            sx={(theme) => ({
+                                                color:
+                                                    row.diff7 > 0
+                                                        ? theme.palette.mode === 'dark'
+                                                            ? theme.palette.success.light
+                                                            : theme.palette.success.dark
+                                                        : row.diff7 < 0
+                                                            ? theme.palette.mode === 'dark'
+                                                                ? theme.palette.error.light
+                                                                : theme.palette.error.dark
+                                                            : 'inherit',
+                                            })}
+                                        >
                                             {formatDiff(row.diff7, row.unit)}
                                             {row.diff7 > 0 ? <TrendingUpIcon fontSize='inherit' /> : row.diff7 < 0 ? <TrendingDownIcon fontSize='inherit' /> : null}
                                             <br />
                                             ({formatRate(row.total7, row.prev7)})
                                         </TableCell>
-                                        <TableCell sx={{ color: row.diff30 > 0 ? 'green' : row.diff30 < 0 ? 'red' : 'inherit' }}>
+                                        <TableCell
+                                            sx={(theme) => ({
+                                                color:
+                                                    row.diff30 > 0
+                                                        ? theme.palette.mode === 'dark'
+                                                            ? theme.palette.success.light
+                                                            : theme.palette.success.dark
+                                                        : row.diff30 < 0
+                                                            ? theme.palette.mode === 'dark'
+                                                                ? theme.palette.error.light
+                                                                : theme.palette.error.dark
+                                                            : 'inherit',
+                                            })}
+                                        >
                                             {formatDiff(row.diff30, row.unit)}
                                             {row.diff30 > 0 ? <TrendingUpIcon fontSize='inherit' /> : row.diff30 < 0 ? <TrendingDownIcon fontSize='inherit' /> : null}
                                             <br />
@@ -247,13 +273,39 @@ function RecordTrend() {
                                 {decRows.map(row => (
                                     <TableRow key={row.name}>
                                         <TableCell>{row.name}</TableCell>
-                                        <TableCell sx={{ color: row.diff7 > 0 ? 'green' : row.diff7 < 0 ? 'red' : 'inherit' }}>
+                                        <TableCell
+                                            sx={(theme) => ({
+                                                color:
+                                                    row.diff7 > 0
+                                                        ? theme.palette.mode === 'dark'
+                                                            ? theme.palette.success.light
+                                                            : theme.palette.success.dark
+                                                        : row.diff7 < 0
+                                                            ? theme.palette.mode === 'dark'
+                                                                ? theme.palette.error.light
+                                                                : theme.palette.error.dark
+                                                            : 'inherit',
+                                            })}
+                                        >
                                             {formatDiff(row.diff7, row.unit)}
                                             {row.diff7 > 0 ? <TrendingUpIcon fontSize='inherit' /> : row.diff7 < 0 ? <TrendingDownIcon fontSize='inherit' /> : null}
                                             <br />
                                             ({formatRate(row.total7, row.prev7)})
                                         </TableCell>
-                                        <TableCell sx={{ color: row.diff30 > 0 ? 'green' : row.diff30 < 0 ? 'red' : 'inherit' }}>
+                                        <TableCell
+                                            sx={(theme) => ({
+                                                color:
+                                                    row.diff30 > 0
+                                                        ? theme.palette.mode === 'dark'
+                                                            ? theme.palette.success.light
+                                                            : theme.palette.success.dark
+                                                        : row.diff30 < 0
+                                                            ? theme.palette.mode === 'dark'
+                                                                ? theme.palette.error.light
+                                                                : theme.palette.error.dark
+                                                            : 'inherit',
+                                            })}
+                                        >
                                             {formatDiff(row.diff30, row.unit)}
                                             {row.diff30 > 0 ? <TrendingUpIcon fontSize='inherit' /> : row.diff30 < 0 ? <TrendingDownIcon fontSize='inherit' /> : null}
                                             <br />

--- a/frontend/src/components/Stopwatch.jsx
+++ b/frontend/src/components/Stopwatch.jsx
@@ -215,11 +215,47 @@ const Stopwatch = forwardRef((props, ref) => {
                         <Box sx={{ ml: 1, display: 'flex', gap: 2 }}>
                             <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
                                 <Typography variant="body2" color="#999" sx={{ lineHeight: 1 }}>{totalLabel7}</Typography>
-                                <Typography variant="caption" sx={{ lineHeight: 1, mt: 0.5, color: diff7 > 0 ? 'green' : diff7 < 0 ? 'red' : undefined }}>{diffLabel7}</Typography>
+                                <Typography
+                                    variant="caption"
+                                    sx={(theme) => ({
+                                        lineHeight: 1,
+                                        mt: 0.5,
+                                        color:
+                                            diff7 > 0
+                                                ? theme.palette.mode === 'dark'
+                                                    ? theme.palette.success.light
+                                                    : theme.palette.success.dark
+                                                : diff7 < 0
+                                                    ? theme.palette.mode === 'dark'
+                                                        ? theme.palette.error.light
+                                                        : theme.palette.error.dark
+                                                    : undefined,
+                                    })}
+                                >
+                                    {diffLabel7}
+                                </Typography>
                             </Box>
                             <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
                                 <Typography variant="body2" color="#999" sx={{ lineHeight: 1 }}>{totalLabel30}</Typography>
-                                <Typography variant="caption" sx={{ lineHeight: 1, mt: 0.5, color: diff30 > 0 ? 'green' : diff30 < 0 ? 'red' : undefined }}>{diffLabel30}</Typography>
+                                <Typography
+                                    variant="caption"
+                                    sx={(theme) => ({
+                                        lineHeight: 1,
+                                        mt: 0.5,
+                                        color:
+                                            diff30 > 0
+                                                ? theme.palette.mode === 'dark'
+                                                    ? theme.palette.success.light
+                                                    : theme.palette.success.dark
+                                                : diff30 < 0
+                                                    ? theme.palette.mode === 'dark'
+                                                        ? theme.palette.error.light
+                                                        : theme.palette.error.dark
+                                                    : undefined,
+                                    })}
+                                >
+                                    {diffLabel30}
+                                </Typography>
                             </Box>
                         </Box>
                     </Box>


### PR DESCRIPTION
## Summary
- adjust stopwatch diff colors to use theme palette
- tweak RecordTrend colors to respect light/dark mode

## Testing
- `npm --prefix frontend run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6880f78be0488329b11f879b2e7d987e