### PR TITLE
Add activity management dialog

### DIFF
--- a/frontend/src/components/ActivityManagementDialog.jsx
+++ b/frontend/src/components/ActivityManagementDialog.jsx
@@ -153,13 +153,14 @@ function ActivityManagementDialog({ open, onClose }) {
         <Dialog open={open} onClose={onClose} maxWidth='md' fullWidth>
             <DialogTitle>アクティビティの管理</DialogTitle>
             <DialogContent>
-                <Box sx={{ height: 400, width: '100%' }}>
+                <Box sx={{ width: '100%' }}>
                     <DataGrid
                         rows={activities}
                         columns={columns}
                         pageSize={5}
                         rowsPerPageOptions={[5]}
                         disableSelectionOnClick
+                        autoHeight
                         processRowUpdate={processRowUpdate}
                         slots={{ toolbar: CustomToolbar }}
                         slotProps={{ toolbar: { addButtonLabel: 'Add Activity', onAddClick: handleAddClick } }}

--- a/frontend/src/components/ActivityManagementDialog.jsx
+++ b/frontend/src/components/ActivityManagementDialog.jsx
@@ -1,48 +1,35 @@
-import React, { useState, useRef } from 'react';
-import { DataGrid } from '@mui/x-data-grid';
-import EditIcon from '@mui/icons-material/Edit';
-import DeleteIcon from '@mui/icons-material/Delete';
-
-// カスタムコンポーネント
+import React, { useState } from 'react';
 import {
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogActions,
     Button,
     Box,
     IconButton,
     Chip
 } from '@mui/material';
+import { DataGrid } from '@mui/x-data-grid';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
 import CustomToolbar from './CustomToolbar';
 import AddActivityDialog from './AddActivityDialog';
 import ConfirmDialog from './ConfirmDialog';
-
-// ユーティリティとコンテキスト
 import getIconForGroup from '../utils/getIconForGroup';
 import { useGroups } from '../contexts/GroupContext';
 import { useUI } from '../contexts/UIContext';
 import { useActivities } from '../contexts/ActivityContext';
 import { setActivityTags } from '../services/api';
-
-// カスタムフック
 import useLocalStorageState from '../hooks/useLocalStorageState';
 
-// ---------------------------------------------------------------------
-// ActivityList コンポーネント本体
-// ---------------------------------------------------------------------
-function ActivityList() {
-    // 通常の状態管理
+function ActivityManagementDialog({ open, onClose }) {
     const { groups } = useGroups();
     const { activities, createActivity, modifyActivity, removeActivity, refreshActivities } = useActivities();
     const [dialogOpen, setDialogOpen] = useState(false);
     const [selectedActivityId, setSelectedActivityId] = useState(null);
-
-    // ローカルストレージで管理する状態
     const [selectedActivity, setSelectedActivity] = useLocalStorageState('selectedActivity', null);
-
-    // UI状態
     const { state, dispatch } = useUI();
 
-    // -----------------------------------------------------------------
-    // イベントハンドラ
-    // -----------------------------------------------------------------
     const handleAddClick = () => setDialogOpen(true);
     const handleDialogClose = () => setDialogOpen(false);
 
@@ -50,7 +37,7 @@ function ActivityList() {
         try {
             await createActivity(activityData);
         } catch (err) {
-            console.error("Failed to add activity:", err);
+            console.error('Failed to add activity:', err);
         }
     };
 
@@ -63,12 +50,11 @@ function ActivityList() {
         try {
             await removeActivity(selectedActivityId);
         } catch (err) {
-            console.error("Failed to delete activity:", err);
+            console.error('Failed to delete activity:', err);
         }
         dispatch({ type: 'SET_CONFIRM_DIALOG', payload: false });
         setSelectedActivityId(null);
     };
-
 
     const handleCancelDelete = () => {
         dispatch({ type: 'SET_CONFIRM_DIALOG', payload: false });
@@ -80,7 +66,7 @@ function ActivityList() {
             await modifyActivity(newRow.id, newRow);
             return newRow;
         } catch (error) {
-            console.error("Failed to update activity:", error);
+            console.error('Failed to update activity:', error);
             throw error;
         }
     };
@@ -90,14 +76,11 @@ function ActivityList() {
         dispatch({ type: 'SET_EDIT_DIALOG', payload: true });
     };
 
-    // -----------------------------------------------------------------
-    // データグリッドの列定義
-    // -----------------------------------------------------------------
     const columns = [
         {
             field: 'is_active',
             headerName: 'State',
-            valueFormatter: (params) => { return (params ? "Active" : "Inactive") }
+            valueFormatter: (params) => { return params ? 'Active' : 'Inactive'; }
         },
         {
             field: 'group_name',
@@ -112,17 +95,13 @@ function ActivityList() {
                 );
             }
         },
-        {
-            field: 'name',
-            headerName: 'Name',
-            width: 200,
-        },
+        { field: 'name', headerName: 'Name', width: 200 },
         {
             field: 'unit',
             headerName: 'Unit',
             valueFormatter: (params) => {
-                if (params === 'minutes') return "分";
-                else if (params === 'count') return "回";
+                if (params === 'minutes') return '分';
+                else if (params === 'count') return '回';
                 else return params;
             }
         },
@@ -140,7 +119,7 @@ function ActivityList() {
                             <Chip
                                 key={tag.id}
                                 label={tag.name}
-                                size="small"
+                                size='small'
                                 sx={{
                                     backgroundColor: tag.color || '#ccc',
                                     color: '#fff',
@@ -157,58 +136,44 @@ function ActivityList() {
             headerName: 'Actions',
             sortable: false,
             filterable: false,
-            renderCell: (params) => {
-                return (
-                    <>
-                        <IconButton onClick={() => handleEditActivity(params.row)} >
-                            <EditIcon />
-                        </IconButton>
-                        <IconButton onClick={() => handleDeleteButtonClick(params.row.id)} >
-                            <DeleteIcon />
-                        </IconButton>
-                    </>
-                );
-            }
+            renderCell: (params) => (
+                <>
+                    <IconButton onClick={() => handleEditActivity(params.row)}>
+                        <EditIcon />
+                    </IconButton>
+                    <IconButton onClick={() => handleDeleteButtonClick(params.row.id)}>
+                        <DeleteIcon />
+                    </IconButton>
+                </>
+            )
         }
     ];
 
-
     return (
-        <div>
-            {/* グリッド表示または管理画面 */}
-            {state.showGrid && (
-                <>
-                    <div style={{ height: 400, width: '100%' }}>
-                        <DataGrid
-                            rows={activities}
-                            columns={columns}
-                            pageSize={5}
-                            rowsPerPageOptions={[5]}
-                            disableSelectionOnClick
-                            processRowUpdate={processRowUpdate}
-                            slots={{ toolbar: CustomToolbar }}
-                            slotProps={{
-                                toolbar: { addButtonLabel: 'Add Activity', onAddClick: handleAddClick }
-                            }}
-                        />
-                    </div>
-                    <Box sx={{ display: 'flex', justifyContent: 'flex-start', mb: 2, mt: 1 }}>
-                        <Button variant="contained" onClick={() => dispatch({ type: 'SET_SHOW_GRID', payload: false })} sx={{ mb: 2 }}>
-                            Close
-                        </Button>
-                    </Box>
-                </>
-
-            )}
-            <AddActivityDialog
-                open={dialogOpen}
-                onClose={handleDialogClose}
-                onSubmit={handleActivityAdded}
-            />
+        <Dialog open={open} onClose={onClose} maxWidth='md' fullWidth>
+            <DialogTitle>アクティビティの管理</DialogTitle>
+            <DialogContent>
+                <Box sx={{ height: 400, width: '100%' }}>
+                    <DataGrid
+                        rows={activities}
+                        columns={columns}
+                        pageSize={5}
+                        rowsPerPageOptions={[5]}
+                        disableSelectionOnClick
+                        processRowUpdate={processRowUpdate}
+                        slots={{ toolbar: CustomToolbar }}
+                        slotProps={{ toolbar: { addButtonLabel: 'Add Activity', onAddClick: handleAddClick } }}
+                    />
+                </Box>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose}>閉じる</Button>
+            </DialogActions>
+            <AddActivityDialog open={dialogOpen} onClose={handleDialogClose} onSubmit={handleActivityAdded} />
             <ConfirmDialog
                 open={state.confirmDialogOpen}
-                title="Confirm Deletion"
-                content="Are you sure you want to delete this activity?"
+                title='Confirm Deletion'
+                content='Are you sure you want to delete this activity?'
                 onConfirm={handleConfirmDelete}
                 onCancel={handleCancelDelete}
             />
@@ -227,22 +192,21 @@ function ActivityList() {
                             });
                             if (activityData.tag_ids && activityData.tag_ids.length > 0) {
                                 await setActivityTags(selectedActivity.id, activityData.tag_ids);
-                              } else if (activityData.tag_ids && activityData.tag_ids.length === 0) {
-                                // タグを空にしたい場合
+                            } else if (activityData.tag_ids && activityData.tag_ids.length === 0) {
                                 await setActivityTags(selectedActivity.id, []);
-                              }
+                            }
                             await refreshActivities();
                             dispatch({ type: 'SET_EDIT_DIALOG', payload: false });
                             setSelectedActivity(null);
                         } catch (err) {
-                            console.error("Failed to update activity:", err);
+                            console.error('Failed to update activity:', err);
                         }
                     }}
                     initialData={selectedActivity}
                 />
             )}
-        </div>
+        </Dialog>
     );
 }
 
-export default ActivityList;
+export default ActivityManagementDialog;

--- a/frontend/src/components/ActivityManagementDialog.jsx
+++ b/frontend/src/components/ActivityManagementDialog.jsx
@@ -19,12 +19,15 @@ import getIconForGroup from '../utils/getIconForGroup';
 import { useGroups } from '../contexts/GroupContext';
 import { useUI } from '../contexts/UIContext';
 import { useActivities } from '../contexts/ActivityContext';
+import { useFilter } from '../contexts/FilterContext';
 import { setActivityTags } from '../services/api';
 import useLocalStorageState from '../hooks/useLocalStorageState';
 
 function ActivityManagementDialog({ open, onClose }) {
     const { groups } = useGroups();
     const { activities, createActivity, modifyActivity, removeActivity, refreshActivities } = useActivities();
+    const { filterState } = useFilter();
+    const { groupFilter, tagFilter } = filterState;
     const [dialogOpen, setDialogOpen] = useState(false);
     const [selectedActivityId, setSelectedActivityId] = useState(null);
     const [selectedActivity, setSelectedActivity] = useLocalStorageState('selectedActivity', null);
@@ -75,6 +78,17 @@ function ActivityManagementDialog({ open, onClose }) {
         setSelectedActivity(activity);
         dispatch({ type: 'SET_EDIT_DIALOG', payload: true });
     };
+
+    const filteredActivities = activities.filter(act => {
+        if (groupFilter && act.group_name !== groupFilter) {
+            return false;
+        }
+        if (tagFilter) {
+            const tags = act.tags?.map(t => t.name) || [];
+            return tags.includes(tagFilter);
+        }
+        return true;
+    });
 
     const columns = [
         {
@@ -155,7 +169,7 @@ function ActivityManagementDialog({ open, onClose }) {
             <DialogContent>
                 <Box sx={{ width: '100%' }}>
                     <DataGrid
-                        rows={activities}
+                        rows={filteredActivities}
                         columns={columns}
                         pageSize={5}
                         rowsPerPageOptions={[5]}

--- a/frontend/src/components/ActivityStart.jsx
+++ b/frontend/src/components/ActivityStart.jsx
@@ -13,6 +13,7 @@ import ToggleButtonGroup, {
 } from '@mui/material/ToggleButtonGroup';
 import GroupManagementDialog from './GroupManagementDialog';
 import TagManagementDialog from './TagManagementDialog';
+import ActivityManagementDialog from './ActivityManagementDialog';
 import getIconForGroup from '../utils/getIconForGroup';
 import { useGroups } from '../contexts/GroupContext';
 import { useFilter } from '../contexts/FilterContext';
@@ -176,7 +177,7 @@ function ActivityStart({ activities, onStart, stopwatchVisible, onStartSubStopwa
                                 </ToggleButton>
                             ))}
                         </ToggleButtonGroup>
-                        {!state.showGrid && !stopwatchVisible && (
+                        {!state.activityDialogOpen && !stopwatchVisible && (
                             <IconButton
                                 onClick={() => dispatch({ type: 'SET_GROUP_DIALOG', payload: true })}
                                 sx={{
@@ -232,7 +233,7 @@ function ActivityStart({ activities, onStart, stopwatchVisible, onStartSubStopwa
                                     {tagName}
                                 </ToggleButton>
                             ))}
-                            {!state.showGrid && !stopwatchVisible && (
+                            {!state.activityDialogOpen && !stopwatchVisible && (
                                 <IconButton
                                     onClick={() => dispatch({ type: 'SET_TAG_DIALOG', payload: true })}
                                     sx={{
@@ -248,7 +249,7 @@ function ActivityStart({ activities, onStart, stopwatchVisible, onStartSubStopwa
                     </Box>
                 </Collapse>
                 {/* アクティビティ表示 */}
-                {!state.showGrid && (
+                {!state.activityDialogOpen && (
                     <>
                         <Typography
                             variant='caption'
@@ -288,9 +289,9 @@ function ActivityStart({ activities, onStart, stopwatchVisible, onStartSubStopwa
                                         </Button>
                                     ))}
                                     {/* 設定アイコンの表示 */}
-                                    {!state.showGrid && !stopwatchVisible && (
+                                    {!state.activityDialogOpen && !stopwatchVisible && (
                                         <IconButton
-                                            variant="contained" onClick={() => dispatch({ type: 'SET_SHOW_GRID', payload: true })}
+                                            variant="contained" onClick={() => dispatch({ type: 'SET_ACTIVITY_DIALOG', payload: true })}
                                             sx={{
                                                 opacity: 0,
                                                 transition: 'opacity 0.3s',
@@ -364,6 +365,10 @@ function ActivityStart({ activities, onStart, stopwatchVisible, onStartSubStopwa
                         </Collapse>
                     </>
                 )}
+                <ActivityManagementDialog
+                    open={state.activityDialogOpen}
+                    onClose={() => dispatch({ type: 'SET_ACTIVITY_DIALOG', payload: false })}
+                />
             </Box>
         </>
     );

--- a/frontend/src/components/RecordingInterface.jsx
+++ b/frontend/src/components/RecordingInterface.jsx
@@ -10,7 +10,6 @@ import ActivityStart from './ActivityStart';
 import AddRecordDialog from './AddRecordDialog';
 import Stopwatch from './Stopwatch';
 import SubStopwatch from './SubStopwatch';
-import ActivityList from './ActivityList';
 import { createRecord } from '../services/api';
 import { calculateTimeDetails } from '../utils/timeUtils';
 import { useRecords } from '../contexts/RecordContext';
@@ -313,7 +312,6 @@ function RecordingInterface() {
                 stopwatchVisible={stopwatchVisible}
                 onStartSubStopwatch={handleStartSubStopwatch}
             />
-            <ActivityList />
             {/* ダイアログ（回数＋確認モード共通） */}
             {state.recordDialogOpen && (recordDialogActivity.unit === 'count' || pendingRecord) && (
                 <AddRecordDialog

--- a/frontend/src/reducers/uiReducer.js
+++ b/frontend/src/reducers/uiReducer.js
@@ -7,7 +7,7 @@ export const DEFAULT_HISTORY_ORDER = [
 ];
 
 export const initialUIState = {
-    showGrid: false,
+    activityDialogOpen: false,
     groupDialogOpen: false,
     editDialogOpen: false,
     confirmDialogOpen: false,
@@ -31,8 +31,8 @@ export const initialUIState = {
 
 export function uiReducer(state, action) {
     switch (action.type) {
-        case 'SET_SHOW_GRID':
-            return { ...state, showGrid: action.payload };
+        case 'SET_ACTIVITY_DIALOG':
+            return { ...state, activityDialogOpen: action.payload };
         case 'SET_GROUP_DIALOG':
             return { ...state, groupDialogOpen: action.payload };
         case 'SET_TAG_DIALOG':


### PR DESCRIPTION
## Summary
- remove ActivityList component
- add ActivityManagementDialog component that uses DataGrid inside a modal
- integrate the new dialog into ActivityStart
- update UI reducer to track activity dialog state
- clean up RecordingInterface

## Testing
- `npm --prefix frontend run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6888c20cca908329b8757a22c8c13695