### PR TITLE
Allow settings dialogs while stopwatch running

### DIFF
--- a/frontend/src/components/ActivityManagementDialog.jsx
+++ b/frontend/src/components/ActivityManagementDialog.jsx
@@ -24,7 +24,7 @@ import { useFilter } from '../contexts/FilterContext';
 import { setActivityTags } from '../services/api';
 import useLocalStorageState from '../hooks/useLocalStorageState';
 
-function ActivityManagementDialog({ open, onClose }) {
+function ActivityManagementDialog({ open, onClose, runningActivityIds = [] }) {
     const { groups } = useGroups();
     const { activities, createActivity, modifyActivity, removeActivity, refreshActivities } = useActivities();
     const { filterState } = useFilter();
@@ -48,6 +48,7 @@ function ActivityManagementDialog({ open, onClose }) {
     };
 
     const handleDeleteButtonClick = (activityId) => {
+        if (runningActivityIds.includes(activityId)) return;
         setSelectedActivityId(activityId);
         dispatch({ type: 'SET_CONFIRM_DIALOG', payload: true });
     };
@@ -78,6 +79,7 @@ function ActivityManagementDialog({ open, onClose }) {
     };
 
     const handleEditActivity = (activity) => {
+        if (runningActivityIds.includes(activity.id)) return;
         setSelectedActivity(activity);
         dispatch({ type: 'SET_EDIT_DIALOG', payload: true });
     };
@@ -154,16 +156,19 @@ function ActivityManagementDialog({ open, onClose }) {
             headerName: 'Actions',
             sortable: false,
             filterable: false,
-            renderCell: (params) => (
-                <>
-                    <IconButton onClick={() => handleEditActivity(params.row)}>
-                        <EditIcon />
-                    </IconButton>
-                    <IconButton onClick={() => handleDeleteButtonClick(params.row.id)}>
-                        <DeleteIcon />
-                    </IconButton>
-                </>
-            )
+            renderCell: (params) => {
+                const disabled = runningActivityIds.includes(params.row.id);
+                return (
+                    <>
+                        <IconButton onClick={() => handleEditActivity(params.row)} disabled={disabled}>
+                            <EditIcon />
+                        </IconButton>
+                        <IconButton onClick={() => handleDeleteButtonClick(params.row.id)} disabled={disabled}>
+                            <DeleteIcon />
+                        </IconButton>
+                    </>
+                );
+            }
         }
     ];
 

--- a/frontend/src/components/ActivityManagementDialog.jsx
+++ b/frontend/src/components/ActivityManagementDialog.jsx
@@ -172,12 +172,15 @@ function ActivityManagementDialog({ open, onClose, runningActivityIds = [] }) {
         }
     ];
 
+    const gridKey = runningActivityIds.join('-');
+
     return (
         <Dialog open={open} onClose={onClose} maxWidth='md' fullWidth>
             <DialogTitle>アクティビティの管理</DialogTitle>
             <DialogContent>
                 <Box sx={{ width: '100%' }}>
                     <DataGrid
+                        key={gridKey}
                         rows={filteredActivities}
                         columns={columns}
                         pageSize={5}

--- a/frontend/src/components/ActivityStart.jsx
+++ b/frontend/src/components/ActivityStart.jsx
@@ -24,7 +24,7 @@ import { styled } from '@mui/material/styles';
 import { useMemo, useState } from 'react';
 import { useSettings } from '../contexts/SettingsContext';
 
-function ActivityStart({ activities, onStart, stopwatchVisible, onStartSubStopwatch }) {
+function ActivityStart({ activities, onStart, stopwatchVisible, onStartSubStopwatch, selectedActivity, subSelectedActivity }) {
     const { groups } = useGroups();
     const { state, dispatch } = useUI();
     const { filterState, setFilterState } = useFilter();
@@ -177,7 +177,7 @@ function ActivityStart({ activities, onStart, stopwatchVisible, onStartSubStopwa
                                 </ToggleButton>
                             ))}
                         </ToggleButtonGroup>
-                        {!state.activityDialogOpen && !stopwatchVisible && (
+                        {!state.activityDialogOpen && (
                             <IconButton
                                 onClick={() => dispatch({ type: 'SET_GROUP_DIALOG', payload: true })}
                                 sx={{
@@ -233,7 +233,7 @@ function ActivityStart({ activities, onStart, stopwatchVisible, onStartSubStopwa
                                     {tagName}
                                 </ToggleButton>
                             ))}
-                            {!state.activityDialogOpen && !stopwatchVisible && (
+                            {!state.activityDialogOpen && (
                                 <IconButton
                                     onClick={() => dispatch({ type: 'SET_TAG_DIALOG', payload: true })}
                                     sx={{
@@ -289,7 +289,7 @@ function ActivityStart({ activities, onStart, stopwatchVisible, onStartSubStopwa
                                         </Button>
                                     ))}
                                     {/* 設定アイコンの表示 */}
-                                    {!state.activityDialogOpen && !stopwatchVisible && (
+                                    {!state.activityDialogOpen && (
                                         <IconButton
                                             variant="contained" onClick={() => dispatch({ type: 'SET_ACTIVITY_DIALOG', payload: true })}
                                             sx={{
@@ -368,6 +368,7 @@ function ActivityStart({ activities, onStart, stopwatchVisible, onStartSubStopwa
                 <ActivityManagementDialog
                     open={state.activityDialogOpen}
                     onClose={() => dispatch({ type: 'SET_ACTIVITY_DIALOG', payload: false })}
+                    runningActivityIds={[selectedActivity?.id, subSelectedActivity?.id].filter(Boolean)}
                 />
             </Box>
         </>

--- a/frontend/src/components/ActivityStart.jsx
+++ b/frontend/src/components/ActivityStart.jsx
@@ -24,7 +24,15 @@ import { styled } from '@mui/material/styles';
 import { useMemo, useState } from 'react';
 import { useSettings } from '../contexts/SettingsContext';
 
-function ActivityStart({ activities, onStart, stopwatchVisible, onStartSubStopwatch, selectedActivity, subSelectedActivity }) {
+function ActivityStart({
+    activities,
+    onStart,
+    stopwatchVisible,
+    onStartSubStopwatch,
+    selectedActivity,
+    subSelectedActivity,
+    subStopwatchVisible,
+}) {
     const { groups } = useGroups();
     const { state, dispatch } = useUI();
     const { filterState, setFilterState } = useFilter();
@@ -368,7 +376,10 @@ function ActivityStart({ activities, onStart, stopwatchVisible, onStartSubStopwa
                 <ActivityManagementDialog
                     open={state.activityDialogOpen}
                     onClose={() => dispatch({ type: 'SET_ACTIVITY_DIALOG', payload: false })}
-                    runningActivityIds={[selectedActivity?.id, subSelectedActivity?.id].filter(Boolean)}
+                    runningActivityIds={[
+                        ...(stopwatchVisible && selectedActivity ? [selectedActivity.id] : []),
+                        ...(subStopwatchVisible && subSelectedActivity ? [subSelectedActivity.id] : []),
+                    ]}
                 />
             </Box>
         </>

--- a/frontend/src/components/RecordingInterface.jsx
+++ b/frontend/src/components/RecordingInterface.jsx
@@ -311,6 +311,8 @@ function RecordingInterface() {
                 onStart={handleStartRecordFromSelect}
                 stopwatchVisible={stopwatchVisible}
                 onStartSubStopwatch={handleStartSubStopwatch}
+                selectedActivity={selectedActivity}
+                subSelectedActivity={subSelectedActivity}
             />
             {/* ダイアログ（回数＋確認モード共通） */}
             {state.recordDialogOpen && (recordDialogActivity.unit === 'count' || pendingRecord) && (

--- a/frontend/src/components/RecordingInterface.jsx
+++ b/frontend/src/components/RecordingInterface.jsx
@@ -313,6 +313,7 @@ function RecordingInterface() {
                 onStartSubStopwatch={handleStartSubStopwatch}
                 selectedActivity={selectedActivity}
                 subSelectedActivity={subSelectedActivity}
+                subStopwatchVisible={subStopwatchVisible}
             />
             {/* ダイアログ（回数＋確認モード共通） */}
             {state.recordDialogOpen && (recordDialogActivity.unit === 'count' || pendingRecord) && (


### PR DESCRIPTION
## Summary
- let settings dialogs open while timers run
- disable edits for activities currently in use

## Testing
- `python -m py_compile $(cat /tmp/py_files.txt)` (fails: py ok)
- `npm install` *(fails due to missing internet)*

------
https://chatgpt.com/codex/tasks/task_e_6888d03b1f448329b8daa3c0d5bbebb1